### PR TITLE
Remove unnecessary configuration option

### DIFF
--- a/site/_posts/2019/2019-04-06-compiling-php-8-from-source-with-jit-support.md
+++ b/site/_posts/2019/2019-04-06-compiling-php-8-from-source-with-jit-support.md
@@ -75,7 +75,7 @@ Next, we want to configure our compilation. You can use `--prefix` flag to set d
 
 ```bash
 ./configure --prefix=/opt/php/php8 --enable-opcache --with-zlib 
---enable-zip --enable-json --enable-sockets --without-pear
+--enable-zip --enable-sockets --without-pear
 ```
 
 To see all available options:


### PR DESCRIPTION
In PHP 8.0, the `ext-json` is now always enabled.

See https://wiki.php.net/rfc/always_enable_json.